### PR TITLE
Enable ECR in database.yml & environment files

### DIFF
--- a/spec/launch/environment/env_spec.cr
+++ b/spec/launch/environment/env_spec.cr
@@ -63,20 +63,20 @@ module Launch::Environment
         it "returns true when array is passed in" do
           launch_env = Env.new "development"
 
-          symbols_result = launch_env.in? %i(development test production)
+          # symbols_result = launch_env.in? %i(development test production)
           strings_result = launch_env.in? %w(development test production)
 
-          symbols_result.should be_truthy
+          # symbols_result.should be_truthy
           strings_result.should be_truthy
         end
 
         it "returns true when tuple is passed in" do
           launch_env = Env.new "development"
 
-          symbols_result = launch_env.in?(:development, :test, :production)
+          # symbols_result = launch_env.in?(:development, :test, :production)
           strings_result = launch_env.in?("development", "test", "production")
 
-          symbols_result.should be_truthy
+          # symbols_result.should be_truthy
           strings_result.should be_truthy
         end
       end
@@ -85,10 +85,10 @@ module Launch::Environment
         it "returns false" do
           launch_env = Env.new "invalid"
 
-          symbols_result = launch_env.in? %w(development test production)
+          # symbols_result = launch_env.in? %w(development test production)
           strings_result = launch_env.in? %w(development test production)
 
-          symbols_result.should be_falsey
+          # symbols_result.should be_falsey
           strings_result.should be_falsey
         end
       end

--- a/spec/launch/environment/env_spec.cr
+++ b/spec/launch/environment/env_spec.cr
@@ -36,14 +36,14 @@ module Launch::Environment
 
       it "returns true when the environment matches the argument(Symbol)" do
         launch_env = Env.new "staging"
-        result = launch_env == :staging
+        result = launch_env == "staging"
 
         result.should be_truthy
       end
 
       it "returns false when the environment matches the argument" do
         launch_env = Env.new "invalid"
-        result = launch_env == :staging
+        result = launch_env == "staging"
 
         result.should be_falsey
       end

--- a/spec/launch/environment/loader_spec.cr
+++ b/spec/launch/environment/loader_spec.cr
@@ -11,12 +11,12 @@ module Launch::Environment
     end
 
     it "load settings from YAML file" do
-      environment = Loader.new(:fake_env, "./spec/support/config/")
+      environment = Loader.new("fake_env", "./spec/support/config/")
       environment.settings.should be_a Launch::Environment::Settings
     end
 
     it "loads encrypted YAML settings" do
-      environment = Loader.new(:production, "./spec/support/config/")
+      environment = Loader.new("production", "./spec/support/config/")
       environment.settings.should be_a Launch::Environment::Settings
     end
   end

--- a/spec/launch/environment/loader_spec.cr
+++ b/spec/launch/environment/loader_spec.cr
@@ -6,7 +6,7 @@ module Launch::Environment
 
     it "raises error for non existent environment settings" do
       expect_raises Launch::Exceptions::Environment do
-        Loader.new("unknown", "./spec/support/config/")
+        Loader.new("unknown", "./spec/support/config/").settings
       end
     end
 

--- a/spec/launch/launch_spec.cr
+++ b/spec/launch/launch_spec.cr
@@ -8,10 +8,10 @@ describe Launch do
   describe ".env" do
     it "should return test" do
       Launch.env.test?.should be_truthy
-      Launch.env.==(:test).should be_truthy
-      Launch.env.==(:development).should be_falsey
-      Launch.env.!=(:development).should be_truthy
-      Launch.env.!=(:test).should be_falsey
+      Launch.env.==("test").should be_truthy
+      Launch.env.==("development").should be_falsey
+      Launch.env.!=("development").should be_truthy
+      Launch.env.!=("test").should be_falsey
     end
   end
 
@@ -19,13 +19,13 @@ describe Launch do
     context "when switching environments" do
       it "changes environment from TEST to PRODUCTION" do
         current_settings = Launch.settings
-        Launch.env = :production
+        Launch.env = "production"
         current_settings.port.should eq 3000
         Launch.settings.port.should eq 4000
       end
 
       it "sets Launch environment from yaml settings file" do
-        Launch.env = :development
+        Launch.env = "development"
         Launch.settings.name.should eq "development_settings"
       end
     end
@@ -34,7 +34,7 @@ describe Launch do
   describe Launch::Server do
     describe ".configure" do
       it "overrides current environment settings" do
-        Launch.env = :test
+        Launch.env = "test"
 
         Launch::Server.configure do |server|
           server.name = "Hello World App"
@@ -53,7 +53,7 @@ describe Launch do
       end
 
       it "retains environment.yml settings that haven't been overwritten" do
-        Launch.env = :test
+        Launch.env = "test"
         expected_session = {:key => "launch.session", :store => :signed_cookie, :expires => 0}
         expected_secrets = {
           "description" => "Store your test secrets credentials and settings here.",

--- a/src/launch/cli/commands/encrypt.cr
+++ b/src/launch/cli/commands/encrypt.cr
@@ -19,7 +19,7 @@ module Launch::CLI
         unencrypted_file = "config/credentials.yml"
 
         unless File.exists?(unencrypted_file) || File.exists?(encrypted_file)
-          raise Exceptions::Environment.new("./config/credentials.yml.", "enc")
+          raise Exceptions::Credentials.new
         end
 
         if File.exists?(encrypted_file)

--- a/src/launch/cli/templates/app/config/application.cr.ecr
+++ b/src/launch/cli/templates/app/config/application.cr.ecr
@@ -6,11 +6,11 @@
 #
 # > We recommend not modifying the order of the requires since the order will
 # affect the behavior of the application.
+require "launch"
 
 require "./database"
 require "../db/migrations/*"
 
-require "launch"
 require "./settings"
 require "./logger"
 require "./i18n"

--- a/src/launch/cli/templates/app/config/database.cr.ecr
+++ b/src/launch/cli/templates/app/config/database.cr.ecr
@@ -1,13 +1,13 @@
+require "ecr/macros"
 require "log"
 require "jennifer"
+require "launch/extensions/jennifer"
 require "jennifer_sqlite3_adapter"
 # require "jennifer/adapter/postgres" # for PostgreSQL
 # require "jennifer/adapter/mysql" for MySQL
 
-APP_ENV = ENV["LAUNCH_ENV"]? || "development"
-Jennifer::Config.read("config/database.yml", APP_ENV)
-Jennifer::Config.from_uri(ENV["DATABASE_URI"]) if ENV.has_key?("DATABASE_URI")
+Jennifer::Config.parse(ECR.render("config/database.yml"), ENV["LAUNCH_ENV"]? || "development")
 
 Jennifer::Config.configure do |conf|
-  conf.logger.level = APP_ENV == "development" ? Log::Severity::Debug : Log::Severity::Error
+  conf.logger.level = ENV["LAUNCH_ENV"]? == "development" ? Log::Severity::Debug : Log::Severity::Error
 end

--- a/src/launch/environment.cr
+++ b/src/launch/environment.cr
@@ -5,8 +5,6 @@ require "./environment/settings"
 require "./support/file_encryptor"
 
 module Launch::Environment
-  alias EnvType = String
-
   macro included
     class_property path : String = "./config/environments/"
     @@settings : Settings?
@@ -20,7 +18,7 @@ module Launch::Environment
       @@credentials ||= Loader.new(env.to_s, path).credentials
     end
 
-    def self.env=(env : EnvType)
+    def self.env=(env : String)
       @@env = Env.new(env.to_s)
       @@settings = Loader.new(env, path).settings
     end

--- a/src/launch/environment.cr
+++ b/src/launch/environment.cr
@@ -5,7 +5,7 @@ require "./environment/settings"
 require "./support/file_encryptor"
 
 module Launch::Environment
-  alias EnvType = String | Symbol
+  alias EnvType = String
 
   macro included
     class_property path : String = "./config/environments/"

--- a/src/launch/environment.cr
+++ b/src/launch/environment.cr
@@ -14,9 +14,6 @@ module Launch::Environment
 
     def self.settings
       @@settings ||= Loader.new(env.to_s, path).settings
-      # Dont rescue errors if environment yml doesn't exist.
-      # rescue Launch::Exceptions::Environment
-      #   @@settings = Settings.from_yaml("default: settings")
     end
 
     def self.credentials

--- a/src/launch/environment.cr
+++ b/src/launch/environment.cr
@@ -1,4 +1,7 @@
-require "./environment/**"
+require "./environment/env"
+require "./environment/loader"
+require "./environment/logging"
+require "./environment/settings"
 require "./support/file_encryptor"
 
 module Launch::Environment

--- a/src/launch/environment/env.cr
+++ b/src/launch/environment/env.cr
@@ -6,7 +6,7 @@ module Launch::Environment
       ENV[LAUNCH_ENV] = @env
     end
 
-    def in?(env_list : Array(EnvType))
+    def in?(env_list : Array(String))
       env_list.any? { |env2| self == env2 }
     end
 
@@ -18,7 +18,7 @@ module Launch::Environment
       io << @env
     end
 
-    def ==(env2 : EnvType)
+    def ==(env2 : String)
       @env == env2.to_s.downcase
     end
 

--- a/src/launch/environment/file_loader.cr
+++ b/src/launch/environment/file_loader.cr
@@ -1,14 +1,14 @@
 # This file loads all the .yml files in config/environments for ecr processing.
 
 # Iterate through files generating a string that will be turned into code.
-# Adds the output of `Launch::Environment::Loader#render_environment` to `@environment_files`
+# Adds the output of `ECR.render` to `@environment_files`
 def build_ecr_rendering_code
   dir = "#{Dir.current}/#{ARGV[0]}"
   files = Dir.children(dir) # .filter where extension != .yml
 
   str = ""
   files.each do |file|
-    str += "environment_files[\"#{file.split(".")[0]}\"] = render_environment \"#{dir}/#{file}\"\n"
+    str += "environment_files[\"#{file.split(".")[0]}\"] = ECR.render \"#{dir}/#{file}\"\n"
   end
   str
 end

--- a/src/launch/environment/file_loader.cr
+++ b/src/launch/environment/file_loader.cr
@@ -8,7 +8,7 @@ def build_ecr_rendering_code
 
   str = ""
   files.each do |file|
-    str += "@environment_files[\"#{file.split(".")[0]}\"] = render_environment \"#{dir}/#{file}\"\n"
+    str += "environment_files[\"#{file.split(".")[0]}\"] = render_environment \"#{dir}/#{file}\"\n"
   end
   str
 end

--- a/src/launch/environment/file_loader.cr
+++ b/src/launch/environment/file_loader.cr
@@ -1,16 +1,54 @@
 # This file loads all the .yml files in config/environments for ecr processing.
 
-# Iterate through files generating a string that will be turned into code.
-# Adds the output of `ECR.render` to `@environment_files`
-def build_ecr_rendering_code
-  dir = "#{Dir.current}/#{ARGV[0]}"
-  files = Dir.children(dir) # .filter where extension != .yml
+class FileLoader
+  @path : String
+  @current_dir : String
+  @testing_path : String
+  @data : Hash(String, String) = {"code" => "", "testing_path" => "false"}
 
-  str = ""
-  files.each do |file|
-    str += "environment_files[\"#{file.split(".")[0]}\"] = ECR.render \"#{dir}/#{file}\"\n"
+  def initialize(path : String)
+    @current_dir = Dir.current
+    @path = @current_dir + path
+    @testing_path = @current_dir + "/spec/support/config"
   end
-  str
+
+  # Iterate through files generating a string that will be turned into code.
+  # Adds the output of `ECR.render` to `@environment_files`
+  def generate_code : Hash(String, String)
+    files = fetch_files
+
+    @data["code"] = ""
+    files.each { |file| @data["code"] += code(file) }
+    @data
+  end
+
+  private def fetch_files : Array(String)
+    if File.exists?(@path)
+      Dir.children(@path).reject! { |f| ext(f) != "yml" }
+    elsif File.exists?(@testing_path)
+      @data["testing_path"] = "true"
+      @path = @testing_path
+      Dir.children(@testing_path).reject! { |f| ext(f) != "yml" }
+    else
+      raise File::NotFoundError.new("", file: ARGV[0])
+    end
+  end
+
+  private def ext(file : String) : String
+    split(file).last
+  end
+
+  private def file_name(file : String) : String
+    split(file).first
+  end
+
+  private def split(file : String) : Array(String)
+    file.split(".")
+  end
+
+  private def code(file : String) : String
+    "environment_files[\"#{file_name(file)}\"] = ECR.render \"#{@path}/#{file}\"\n"
+  end
 end
 
-puts build_ecr_rendering_code
+puts FileLoader.new(ARGV[0]).generate_code["code"]

--- a/src/launch/environment/file_loader.cr
+++ b/src/launch/environment/file_loader.cr
@@ -1,36 +1,34 @@
 # This file loads all the .yml files in config/environments for ecr processing.
 
 class FileLoader
-  @path : String
   @current_dir : String
   @testing_path : String
-  @data : Hash(String, String) = {"code" => "", "testing_path" => "false"}
+  @data : String
+  @path : String
 
-  def initialize(path : String)
+  def initialize(@path : String)
+    @data = ""
     @current_dir = Dir.current
-    @path = @current_dir + path
     @testing_path = @current_dir + "/spec/support/config"
   end
 
   # Iterate through files generating a string that will be turned into code.
   # Adds the output of `ECR.render` to `@environment_files`
-  def generate_code : Hash(String, String)
+  def generate_code : String
     files = fetch_files
 
-    @data["code"] = ""
-    files.each { |file| @data["code"] += code(file) }
+    files.each { |file| @data += code(file) }
     @data
   end
 
   private def fetch_files : Array(String)
-    if File.exists?(@path)
-      Dir.children(@path).reject! { |f| ext(f) != "yml" }
+    if File.exists?(path)
+      Dir.children(path).reject! { |f| ext(f) != "yml" }
     elsif File.exists?(@testing_path)
-      @data["testing_path"] = "true"
       @path = @testing_path
       Dir.children(@testing_path).reject! { |f| ext(f) != "yml" }
     else
-      raise File::NotFoundError.new("", file: ARGV[0])
+      raise File::NotFoundError.new(@data["path"], file: ARGV[0])
     end
   end
 
@@ -47,8 +45,12 @@ class FileLoader
   end
 
   private def code(file : String) : String
-    "environment_files[\"#{file_name(file)}\"] = ECR.render \"#{@path}/#{file}\"\n"
+    "environment_files[\"#{file_name(file)}\"] = ECR.render \"#{path}/#{file}\"\n"
+  end
+
+  private def path : String
+    @path
   end
 end
 
-puts FileLoader.new(ARGV[0]).generate_code["code"]
+puts FileLoader.new(ARGV[0]).generate_code

--- a/src/launch/environment/file_loader.cr
+++ b/src/launch/environment/file_loader.cr
@@ -1,0 +1,16 @@
+# This file loads all the .yml files in config/environments for ecr processing.
+
+# Iterate through files generating a string that will be turned into code.
+# Adds the output of `Launch::Environment::Loader#render_environment` to `@environment_files`
+def build_ecr_rendering_code
+  dir = "#{Dir.current}/#{ARGV[0]}"
+  files = Dir.children(dir) # .filter where extension != .yml
+
+  str = ""
+  files.each do |file|
+    str += "@environment_files[\"#{file.split(".")[0]}\"] = render_environment \"#{dir}/#{file}\"\n"
+  end
+  str
+end
+
+puts build_ecr_rendering_code

--- a/src/launch/environment/loader.cr
+++ b/src/launch/environment/loader.cr
@@ -12,8 +12,8 @@ module Launch::Environment
     def settings
       environment_files = Hash(String, String).new
       {{ run("./file_loader.cr", "config/environments").id }}
-      Settings.from_yaml(@environment_files[@environment])
-    rescue e : Exception
+      Settings.from_yaml(environment_files[@environment])
+    rescue e : KeyError
       raise Exceptions::Environment.new(@path, @environment)
     end
 

--- a/src/launch/environment/loader.cr
+++ b/src/launch/environment/loader.cr
@@ -3,20 +3,22 @@ require "ecr/macros"
 module Launch::Environment
   class Loader
     def initialize(
-      @environment : Launch::Environment::EnvType = Launch.env.to_s,
+      @environment : String = Launch.env.to_s,
       @path : String = Launch.environment_path
     )
     end
 
-    def settings
+    def settings : Settings
       environment_files = Hash(String, String).new
-      {{ run("./file_loader.cr", "config/environments").id }}
+      {{ run("./file_loader.cr", "/config/environments").id }}
+      pp environment_files.keys
+      pp @environment
       Settings.from_yaml(environment_files[@environment])
-    rescue e : KeyError
-      raise Exceptions::Environment.new(@path, @environment)
+    rescue e : Exception
+      raise Exceptions::Environment.new("/config/environments/", @environment)
     end
 
-    def credentials
+    def credentials : YAML::Any
       YAML.parse(Support::FileEncryptor.read_as_string(credentials_settings_file))
     rescue e : Exception
       puts e
@@ -24,7 +26,7 @@ module Launch::Environment
       raise "No credentials.yml.enc file"
     end
 
-    private def credentials_settings_file
+    private def credentials_settings_file : String
       @credentials ||= File.expand_path("./config/credentials.yml.enc")
     end
   end

--- a/src/launch/environment/loader.cr
+++ b/src/launch/environment/loader.cr
@@ -10,12 +10,10 @@ module Launch::Environment
 
     def settings : Settings
       environment_files = Hash(String, String).new
-      {{ run("./file_loader.cr", "/config/environments").id }}
-      pp environment_files.keys
-      pp @environment
+      {{ run("./file_loader.cr", "/config/environments") }}
       Settings.from_yaml(environment_files[@environment])
-    rescue e : Exception
-      raise Exceptions::Environment.new("/config/environments/", @environment)
+    rescue e : KeyError
+      raise Exceptions::Environment.new(@environment)
     end
 
     def credentials : YAML::Any

--- a/src/launch/environment/loader.cr
+++ b/src/launch/environment/loader.cr
@@ -1,5 +1,4 @@
-require "kilt"
-require "kilt/ecr"
+require "ecr/macros"
 
 module Launch::Environment
   class Loader
@@ -27,12 +26,6 @@ module Launch::Environment
 
     private def credentials_settings_file
       @credentials ||= File.expand_path("./config/credentials.yml.enc")
-    end
-
-    private macro render_environment(filename)
-      String.build do |__kilt_io__|
-        {{Kilt::ENGINES["ecr"]}}("{{filename.id}}", "__kilt_io__")
-      end
     end
   end
 end

--- a/src/launch/environment/loader.cr
+++ b/src/launch/environment/loader.cr
@@ -3,16 +3,18 @@ require "kilt/ecr"
 
 module Launch::Environment
   class Loader
-    property environment_files = Hash(String, String).new
-
-    def initialize(@environment : Launch::Environment::EnvType = Launch.env.to_s,
-                   @path : String = Launch.environment_path)
-      raise Exceptions::Environment.new(@path, @environment) unless settings_file_exist?
+    def initialize(
+      @environment : Launch::Environment::EnvType = Launch.env.to_s,
+      @path : String = Launch.environment_path
+    )
     end
 
     def settings
+      environment_files = Hash(String, String).new
       {{ run("./file_loader.cr", "config/environments").id }}
-      Settings.from_yaml(@environment_files[Launch.env.to_s])
+      Settings.from_yaml(@environment_files[@environment])
+    rescue e : Exception
+      raise Exceptions::Environment.new(@path, @environment)
     end
 
     def credentials
@@ -23,31 +25,13 @@ module Launch::Environment
       raise "No credentials.yml.enc file"
     end
 
-    private def settings_content
-      if File.exists?(yml_settings_file)
-        File.read(yml_settings_file)
-      end
-    end
-
-    private def yml_settings_file
-      @yml_settings ||= File.expand_path("#{@path}/#{@environment}.yml")
-    end
-
     private def credentials_settings_file
       @credentials ||= File.expand_path("./config/credentials.yml.enc")
     end
 
-    private def settings_file_exist?
-      File.exists?(yml_settings_file)
-    end
-
     private macro render_environment(filename)
       String.build do |__kilt_io__|
-        {% if Kilt::ENGINES["ecr"] %}
-          {{Kilt::ENGINES["ecr"]}}("{{filename.id}}", "__kilt_io__")
-        {% else %}
-          raise Kilt::Exception.new("Unsupported template engine for extension: \"" + {{ext}} + "\"")
-        {% end %}
+        {{Kilt::ENGINES["ecr"]}}("{{filename.id}}", "__kilt_io__")
       end
     end
   end

--- a/src/launch/exceptions/exceptions.cr
+++ b/src/launch/exceptions/exceptions.cr
@@ -13,8 +13,20 @@ module Launch
     end
 
     class Environment < Exception
-      def initialize(path, environment)
-        super("Environment file not found for #{path}#{environment}")
+      def initialize(environment)
+        super(
+          "Environment file not found for #{environment}. " +
+          "Please ensure #{environment}.yml exists in config/environments"
+        )
+      end
+    end
+
+    class Credentials < Exception
+      def initialize
+        super(
+          "Credentials file not found. " +
+          "Please ensure credentials.yml.enc exists in config"
+        )
       end
     end
 

--- a/src/launch/extensions/jennifer.cr
+++ b/src/launch/extensions/jennifer.cr
@@ -1,0 +1,28 @@
+# :nodoc:
+module Jennifer
+  # Jennifer does not expose any method to configure with a string.
+  # All config entries expect a path. Because Launch allows ecr in the database.yml
+  # file, we need to extend jennifer. These methods copy the current config
+  # methods except we bypass the `File.read` portion and go straight to parsing the YAML.
+  # :nodoc:
+  class Config
+    def self.parse(*args, **opts)
+      config.parse(*args, **opts)
+    end
+
+    def parse(data : String, env : Symbol = :development)
+      parse(data, env.to_s)
+    end
+
+    # ditto
+    def parse(data : String, env : String)
+      parse(data) { |document| document[env] }
+    end
+
+    # Reads configurations from the file with given `string`.
+    def parse(data : String)
+      source = yield YAML.parse(data)
+      from_yaml(source)
+    end
+  end
+end


### PR DESCRIPTION
### Description of the Change
Allows users to write ecr directly into environment YAML files. We can get rid of "settings.cr" and use the yml as the single source of information now that encrypted variables can be accessed. Still need to remove the unused code in loader.cr.

### Alternate Designs

Leaving settings.cr as the place to overwrite settings with env/encrypted variables.

### Benefits

Single source of information, less files to work with.

### Possible Drawbacks
Slower compilation. Using `run` to run a separate file called `file_loader` because we can't use `Dir` & `File` in macros.
