### PR TITLE
Fix Database Shard Versions

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -43,15 +43,15 @@ dependencies:
 
   pg:
     github: will/crystal-pg
-    version: ~> 0.22.1
+    version: ~> 0.21.1
 
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.12.0
+    version: ~> 0.11.2
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.17.0
+    version: ~> 0.16.0
 
   redis:
     github: stefanwille/crystal-redis


### PR DESCRIPTION
Downgrades the database shards. Need to open PR on jennifer_sqlite3_adapter to upgrade db from 0.9.0 to 0.10.0.